### PR TITLE
init should check if it's main

### DIFF
--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -255,5 +255,5 @@ def _metadata():
     )
 
 
-#if __name__ == '__main__':
-cli()
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
This will make it so that `python -m docsteady` will execute docsteady properly as well.