### PR TITLE
Remove timestamp from spec template

### DIFF
--- a/docsteady/templates/dm-spec.latex.jinja2
+++ b/docsteady/templates/dm-spec.latex.jinja2
@@ -166,3 +166,5 @@ Version & Status & Priority & Verification Type & Owner
     \end{longtable}
 {% endif %}
 {% endfor %}
+
+\appendix

--- a/docsteady/templates/dm-spec.latex.jinja2
+++ b/docsteady/templates/dm-spec.latex.jinja2
@@ -11,7 +11,6 @@
 {%- endmacro -%}
 
 % generated from JIRA project {{ metadata.project }}
-% on {{ metadata.created_on.format('YYYY-MM-DD HH:mm:ss') }}
 % using template at {{ metadata.template }}.
 % Collecting ATM data from folder: "{{ metadata.folder }}"
 % using docsteady version {{ metadata.docsteady_version }}


### PR DESCRIPTION
The change is very trivial but will avoid Travis overhead.