### PR TITLE
DM-18410: Use foldertree API and add example_code custom field

### DIFF
--- a/docsteady/config.py
+++ b/docsteady/config.py
@@ -35,6 +35,8 @@ class Config:
     TESTCYCLE_URL = f"{ATM_API}/testrun/{{testrun}}"
     TESTPLAN_URL = f"{ATM_API}/testplan/{{testplan}}"
     TESTRESULTS_URL = f"{ATM_API}/testrun/{{testrun}}/testresults"
+    # FIXME: Using undocumented API
+    FOLDERTREE_API = f"{JIRA_INSTANCE}/rest/tests/1.0/project/12800/foldertree/testcase"
     PANDOC_TYPE = None
     AUTH = None
     REQID_FIELD = "customfield_12001"

--- a/docsteady/spec.py
+++ b/docsteady/spec.py
@@ -52,6 +52,20 @@ class TestStep(Schema):
     description = MarkdownableHtmlPandocField()
     expected_result = MarkdownableHtmlPandocField(load_from="expectedResult")
     test_data = MarkdownableHtmlPandocField(load_from="testData")
+    custom_field_values = fields.List(fields.Dict(), load_from="customFieldValues")
+
+    # Custom fields
+    example_code = MarkdownableHtmlPandocField()  # name: "Example Code"
+
+    @pre_load(pass_many=False)
+    def extract_custom_fields(self, data):
+        # Custom fields
+        custom_field_values = data.get("customFieldValues", list())
+        for custom_field in custom_field_values:
+            string_value = custom_field["stringValue"]
+            name = custom_field["customField"]["name"]
+            name = name.lower().replace(" ", "_")
+            data[name] = string_value
 
 
 class TestCase(Schema):

--- a/docsteady/templates/dm-spec.latex.jinja2
+++ b/docsteady/templates/dm-spec.latex.jinja2
@@ -153,6 +153,13 @@ Version & Status & Priority & Verification Type & Owner
                 \vspace{\dp0}
             {% endif %}
             } \end{minipage} \\ \cline{2-3}
+            {% if step.example_code %}
+                & Example Code &
+                \begin{minipage}[t]{13cm}{\footnotesize
+                \texttt{ {{ step.example_code }} }
+                \vspace{\dp0}
+                } \end{minipage} \\ \cline{2-3}
+            {% endif %}
             & Expected Result &
             {% if step.expected_result %}
                 \begin{minipage}[t]{13cm}{\footnotesize

--- a/docsteady/utils.py
+++ b/docsteady/utils.py
@@ -197,6 +197,6 @@ def get_folders(target_folder):
     collect_children(foldertree_json["children"], "", folders)
     target_folders = []
     for folder in folders:
-        if target_folder in folder:
+        if folder.startswith(target_folder):
             target_folders.append(folder)
     return target_folders

--- a/docsteady/utils.py
+++ b/docsteady/utils.py
@@ -176,3 +176,27 @@ def rewrite_strong_to_subsection(content, extractable):
     #     new_order = list(found_items.values())
     #     new_order.extend(shelved)
     return "".join(new_order)
+
+
+# FIXME: This can be removed ATM API testcases/search API is fixed
+def get_folders(target_folder):
+    """
+    Get all folders that that have the target folder in their string
+    """
+    def collect_children(children, path, folders):
+        """Recursively collection children"""
+        for child in children:
+            child_path = path + f"/{child['name']}"
+            folders.append(child_path)
+            if len(child["children"]):
+                collect_children(child["children"], child_path, folders)
+    resp = requests.get(Config.FOLDERTREE_API, auth=Config.AUTH)
+    foldertree_json = resp.json()
+
+    folders = []
+    collect_children(foldertree_json["children"], "", folders)
+    target_folders = []
+    for folder in folders:
+        if target_folder in folder:
+            target_folders.append(folder)
+    return target_folders


### PR DESCRIPTION
The new version of Adaptavist Test Management broke the testcase search API. This uses an internal versioned API from ATM which utilizes a "foldertree" endpoint to discover folders and build a query based on that.