### PR TITLE
Tickets/dm 18617

### DIFF
--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -33,6 +33,7 @@ from .config import Config
 from .formatters import alphanum_key, alphanum_map_sort
 from .spec import build_spec_model
 from .tplan import build_tpr_model
+from .vcd import build_vcd_model
 
 try:
     __version__ = get_distribution(__name__).version
@@ -253,6 +254,27 @@ def _metadata():
         docsteady_version=__version__,
         project="LVV"
     )
+
+
+
+@cli.command("generate-vcd")
+@click.option('--format', default='latex', help='Pandoc output format (see pandoc for options)')
+@click.option('--username', prompt="Jira Username", envvar="JIRA_USER", help="Jira username")
+@click.option('--password', prompt="Jira Password", hide_input=True,
+              envvar="JIRA_PASSWORD", help="Jira Password")
+@click.argument('component')
+@click.argument('path', required=False, type=click.Path())
+def generate_vcd(format, username, password, component, path):
+    """Given a specific subsystem, it build the VCD.
+    If specified, PATH is the resulting output.
+    """
+    global OUTPUT_FORMAT
+    OUTPUT_FORMAT = format
+    Config.AUTH = (username, password)
+    target = "vcd"
+
+    vcd_dict = build_vcd_model(component)
+
 
 
 if __name__ == '__main__':

--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -33,7 +33,7 @@ from .config import Config
 from .formatters import alphanum_key, alphanum_map_sort
 from .spec import build_spec_model
 from .tplan import build_tpr_model
-from .vcd import build_vcd_model
+from .vcd import build_vcd_model, vcdsql
 
 try:
     __version__ = get_distribution(__name__).version
@@ -262,9 +262,10 @@ def _metadata():
 @click.option('--username', prompt="Jira Username", envvar="JIRA_USER", help="Jira username")
 @click.option('--password', prompt="Jira Password", hide_input=True,
               envvar="JIRA_PASSWORD", help="Jira Password")
+@click.option('--sql', required=False, default=False)
 @click.argument('component')
 @click.argument('path', required=False, type=click.Path())
-def generate_vcd(format, username, password, component, path):
+def generate_vcd(format, username, password, sql, component, path):
     """Given a specific subsystem, it build the VCD.
     If specified, PATH is the resulting output.
     """
@@ -273,7 +274,11 @@ def generate_vcd(format, username, password, component, path):
     Config.AUTH = (username, password)
     target = "vcd"
 
-    vcd_dict = build_vcd_model(component)
+    if sql:
+        print('Building model using direct SQL access')
+        vcd_dict = vcdsql(component, username, password)
+    else:
+        vcd_dict = build_vcd_model(component)
 
 
 

--- a/docsteady/config.py
+++ b/docsteady/config.py
@@ -26,6 +26,7 @@ class Config:
     JIRA_INSTANCE = "https://jira.lsstcorp.org"
     JIRA_API = f"{JIRA_INSTANCE}/rest/api/latest"
     ATM_API = f"{JIRA_INSTANCE}/rest/atm/1.0"
+    ATMT_API = f"{JIRA_INSTANCE}/rest/tests/1.0"
     ISSUE_URL = f"{JIRA_API}/issue/{{issue}}"
     ISSUE_UI_URL = f"{JIRA_INSTANCE}/browse/{{issue}}"
     USER_URL = f"{JIRA_API}/user?username={{username}}"
@@ -37,6 +38,8 @@ class Config:
     TESTRESULTS_URL = f"{ATM_API}/testrun/{{testrun}}/testresults"
     ISSUETCASES_URL = f"{ATM_API}/issuelink/{{issuekey}}/testcases"
     TESTCASERESULT_URL = f"{ATM_API}/testcase/{{tcid}}/testresult/latest"
+    TESTPLANCYCLE_URL = f"{ATMT_API}/testresult/{{trk}}?fields=testRun(key,testPlan(key))"
+    TPLANCF_URL = f"{ATM_API}//testplan/{{tpk}}?fields=customFields"
     # FIXME: Using undocumented API
     FOLDERTREE_API = f"{JIRA_INSTANCE}/rest/tests/1.0/project/12800/foldertree/testcase"
     VE_SEARCH_URL = f"{JIRA_API}/search?jql=project%20%3D%20LVV%20AND%20component%20%20%3D%20%27{{cmpnt}}%27%20and%20issuetype%20%3D%20Verification&fields=key,summary,customfield_13511,customfield_13513,customfield_12002,customfield_12206,customfield_13703&maxResults={{maxR}}"

--- a/docsteady/config.py
+++ b/docsteady/config.py
@@ -35,8 +35,11 @@ class Config:
     TESTCYCLE_URL = f"{ATM_API}/testrun/{{testrun}}"
     TESTPLAN_URL = f"{ATM_API}/testplan/{{testplan}}"
     TESTRESULTS_URL = f"{ATM_API}/testrun/{{testrun}}/testresults"
+    ISSUETCASES_URL = f"{ATM_API}/issuelink/{{issuekey}}/testcases"
+    TESTCASERESULT_URL = f"{ATM_API}/testcase/{{tcid}}/testresult/latest"
     # FIXME: Using undocumented API
     FOLDERTREE_API = f"{JIRA_INSTANCE}/rest/tests/1.0/project/12800/foldertree/testcase"
+    VE_SEARCH_URL = f"{JIRA_API}/search?jql=project%20%3D%20LVV%20AND%20component%20%20%3D%20%27{{cmpnt}}%27%20and%20issuetype%20%3D%20Verification&fields=key,summary,customfield_13511,customfield_13513,customfield_12002,customfield_12206,customfield_13703&maxResults={{maxR}}"
     PANDOC_TYPE = None
     AUTH = None
     REQID_FIELD = "customfield_12001"

--- a/docsteady/utils.py
+++ b/docsteady/utils.py
@@ -200,3 +200,11 @@ def get_folders(target_folder):
         if folder.startswith(target_folder):
             target_folders.append(folder)
     return target_folders
+
+def get_tspec(folder):
+    sf = folder.split('/')
+    for d in sf:
+        sd = d.split('|')
+        if len(sd) == 2:
+            return(sd[1])
+    return("")

--- a/docsteady/utils.py
+++ b/docsteady/utils.py
@@ -31,6 +31,8 @@ from marshmallow import fields
 from .config import Config
 import requests
 
+jhost = "140.252.32.64"
+jdb = "jira"
 
 class HtmlPandocField(fields.String):
     """
@@ -208,3 +210,5 @@ def get_tspec(folder):
         if len(sd) == 2:
             return(sd[1])
     return("")
+
+

--- a/docsteady/vcd.py
+++ b/docsteady/vcd.py
@@ -466,8 +466,8 @@ def summary(jc, VEs, reqs, comp):
              "inner join nodeassociation na ON ji.id = na.source_node_id "
              "inner join component c on na.`SINK_NODE_ID`=c.id "
              " where ji.project = 12800 and ji.issuetype = 10602 and c.cname='"+comp+"'")
-    rawres = db_get(jc, query)
-    for s in rawres:
+    veStatus = db_get(jc, query)
+    for s in veStatus:
         print(jst[ s[0] ], s[1])
     
     # get TC versus status
@@ -476,10 +476,23 @@ def summary(jc, VEs, reqs, comp):
 
     fsum = open(comp.lower() +"_summary.tex", 'w')
     print('\\newpage\n\\section{Summary Information}', file=fsum)
-    print('\\begin{longtable}{ll}\n\\toprule', file=fsum)
-    print(f"Number of Requirements: & {mtrs['nr']} \\\\", file=fsum)
-    print(f"Number of Verification Elements: & {mtrs['nv']} \\\\", file=fsum)
-    print(f"Number of Test Cases: & {mtrs['nt']} \\\\", file=fsum)
+
+    #print('\\begin{longtable}{ll}\n\\toprule', file=fsum)
+    print('\\begin{longtable}{rccc}\n\\toprule', file=fsum)
+    print(" & \\textbf{Requirements} & \\textbf{Verification Elements} & \\textbf{Test Cases} \\\\ \\hline", file=fsum)
+    print(f"N.& {mtrs['nr']} & {mtrs['nv']} & {mtrs['nt']} \\\\", file=fsum)
+    #print(f"Number of Requirements: & {mtrs['nr']} \\\\", file=fsum)
+    #print(f"Number of Verification Elements: & {mtrs['nv']} \\\\", file=fsum)
+    #print(f"Number of Test Cases: & {mtrs['nt']} \\\\", file=fsum)
+    print('\\bottomrule\n\\end{longtable}', file=fsum)
+
+    print('\\begin{longtable}{rl}\n\\toprule', file=fsum)
+    print("\\multicolumn{2}{c}{\\textbf{Verification Element Status}} \\\\ \\hline", file=fsum)
+    T = 0
+    for s in veStatus: 
+        T = T + s[1]
+        print(f" {jst[ s[0] ]} & {s[1]} \\\\", file=fsum)
+    print("\\hline\n\\textbf{subtotal} & ", f"{T} \\\\", file=fsum)
     print('\\bottomrule\n\\end{longtable}', file=fsum)
     fsum.close()
 

--- a/docsteady/vcd.py
+++ b/docsteady/vcd.py
@@ -414,7 +414,7 @@ def summary(jc, verification_elements, reqs, comp):
     print("\\multicolumn{2}{c}{\\textbf{Verification Element Status}} \\\\ \\hline", file=fsum)
     t = 0
     for s in ve_status:
-        print(jst[s[0]], s[1])
+        #print(jst[s[0]], s[1])
         t = t + s[1]
         print(f" {jst[s[0]]} & {s[1]} \\\\", file=fsum)
     print("\\hline\n\\textbf{subtotal} & ", f"{t} \\\\", file=fsum)
@@ -460,7 +460,7 @@ def print_vcd(verification_elements, reqs, comp):
             rtype.append(tmptype)
         # print(r, req, reqs[req]['reqDoc'])
         print(bt, f"{req} {nl} {ndr}{reqs[req]['reqDoc']}{ccb}", et + " &", file=fout)
-        print(reqs[req])
+        #print(reqs[req])
         nve = len(reqs[req]['VEs'])
         v = 0
         for ve in reqs[req]['VEs']:

--- a/docsteady/vcd.py
+++ b/docsteady/vcd.py
@@ -1,0 +1,251 @@
+# LSST Data Management System
+# Copyright 2018 AURA/LSST.
+#
+# This product includes software developed by the
+# LSST Project (http://www.lsst.org/).
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the LSST License Statement and
+# the GNU General Public License along with this program.  If not,
+# see <http://www.lsstcorp.org/LegalNotices/>.
+
+"""
+Code for VCD
+"""
+import requests
+from marshmallow import Schema, fields, pre_load
+
+from docsteady.cycle import TestCycle, TestResult
+from docsteady.spec import Issue, TestCase
+from docsteady.utils import owner_for_id, as_arrow, HtmlPandocField, SubsectionableHtmlPandocField, \
+    MarkdownableHtmlPandocField, get_tspec
+from .config import Config
+
+
+class VerificationE(Schema):
+    key = fields.String(required=True)
+    summary = MarkdownableHtmlPandocField()
+    jira_url = fields.String()
+
+    @pre_load(pass_many=False)
+    def extract_fields(self, data):
+        data_fields = data["fields"]
+        data["summary"] = data_fields["summary"]
+        data["jira_url"] = Config.ISSUE_UI_URL.format(issue=data["key"])
+        return data
+
+
+
+def build_vcd_model(component):
+    # build the vcd. Only Verification Issues are considered. 
+
+    fname = component.lower() + "_vcd.tex"
+
+    rs = requests.Session()
+
+    # get component id
+    resp = rs.get("https://jira.lsstcorp.org/rest/api/2/project/LVV/components",
+                        auth=Config.AUTH)
+    cmps = resp.json()
+    cId = ''
+    for c in cmps:
+        if c['name'] == component:
+            cId = c['id']
+            break
+    if cId == '':
+        print(f"Error. Component {{c}} not found in LVV project".format(c=component))
+        exit()
+
+    # get the number of issue in the componenet
+    resp = rs.get(F"https://jira.lsstcorp.org/rest/api/latest/component/{{cid}}/relatedIssueCounts".format(cid=cId),
+                        auth=Config.AUTH)
+    cmpCount = resp.json()
+    maxRes = cmpCount['issueCount']
+
+    print(f"Getting {{maxR}} Verification Elements from {{cmpnt}}.".format(maxR=maxRes, cmpnt=component))
+    resp = rs.get(Config.VE_SEARCH_URL.format(cmpnt=component,maxR=maxRes),
+                        auth=Config.AUTH)
+    resp.raise_for_status()
+
+    velem = {}
+    reqs = {}
+    tcases = {}
+
+    veresp = resp.json()
+    i = 0
+    for ve in veresp['issues']:
+        i = i + 1
+        tmp = {}
+        tmp['key'] = ve['key']
+        #tmp['summary'] = ve['fields']['summary']
+        ves = ve['fields']['summary'].split(':')
+        #tmp['veId'] = ves[0]
+        tmp['veSummary'] = ves[1]
+        tmp['req'] = ve['fields']['customfield_13511']
+        tmp['vmethod'] = ve['fields']['customfield_12002']['value']
+        tmp['reqDoc'] = ve['fields']['customfield_13703']
+        tmp['reqId'] = ve['fields']['customfield_13511']
+        #if 'value' not in ve['fields']['customfield_12206'].keys():
+        if ve['fields']['customfield_12206'] is None:
+        #if 'customfield_12206' not in ve['fields'].keys():
+            tmp['vlevel'] = 'None'
+        else:
+            tmp['vlevel'] = ve['fields']['customfield_12206']['value']
+        if tmp['reqId'] not in reqs.keys():
+            rtmp = {}
+            rtmp['desc'] = ve['fields']['customfield_13513']
+            #print(ve['fields']['customfield_13513'])
+            rtmp['reqDoc'] = ve['fields']['customfield_13703']
+            rtmp['VEs'] = []
+            rtmp['VEs'].append(ves[0])
+            reqs[ tmp['reqId'] ] = rtmp
+        else:
+            reqs[ tmp['reqId'] ]['VEs'].append(ves[0])
+            
+        #print(i, tmp)
+        tcraw = rs.get(Config.ISSUETCASES_URL.format(issuekey=tmp['key']),
+                       auth=Config.AUTH)
+        tcrawj = tcraw.json()
+        tmp['tc'] = []
+        for tc in tcrawj:
+            tmp['tc'].append(tc['key'])
+            #print('     - ',tc['key'])
+            if tc['key'] not in tcases.keys():
+                tctmp = {}
+                if tc['owner']:
+                    tctmp['owner'] = tc['owner']
+                else:
+                    tctmp['owner'] = ""
+                tctmp['critical'] = tc['customFields']['Critical Event?']
+                tctmp['vtype'] = tc['customFields']['Verification Type']
+                if 'objective' in tc.keys():
+                    tctmp['objective'] = tc['objective']
+                else:
+                    tctmp['objective'] = ""
+                tctmp['name'] = tc['name']
+                tctmp['status'] = tc['status']
+                tctmp['folder'] = tc['folder']
+                tctmp['tspec'] = get_tspec(tc['folder'])
+                tcases[ tc['key'] ] = tctmp
+        #print(f"[{{i}} {{ve}} {{veId}} {{vlevel}} ({{ntc}})]  ".format(i=i,ve=tmp['key'], veId=ves[0], vlevel=tmp['vlevel'], ntc=len(tmp['tc'])))
+        velem[ ves[0] ] = tmp
+
+    print("\nGot", len(velem), "Verification Elements on", len(reqs), "Requirements. Found", len(tcases), ' related test cases.')
+
+    for tck in tcases.keys():
+        #print(tck, end="")
+        tcd = rs.get(Config.TESTCASERESULT_URL.format(tcid=tck),
+                     auth=Config.AUTH)
+        if tcd.status_code == 404:
+            #print('(NR)', end="")
+            continue
+        else:
+            tcdj = tcd.json()
+            tmpr = {}
+            if tcdj['status'] == "Pass":
+                tmpr['status'] = 'passed'
+            elif tcdj['status'] == "Conditional Pass":
+                tmpr['status'] = 'cndpass'
+            elif tcdj['status'] == "Fail":
+                tmpr['status'] = 'failed'
+            elif tcdj['status'] == "In Progress":
+                tmpr['status'] = 'inprog'
+            elif tcdj['status'] == "Blocked":
+                tmpr['status'] = 'blocked'
+            else:
+                tmpr['status'] = 'notexec'
+            #print('(', tcdj['status'],')', end="")
+            tmpr['date'] = tcdj['executionDate'][0:10]
+            tmpr['tester'] = tcdj['executedBy']
+            tmpr['key'] = tcdj['key']
+            if 'comment' in tcdj.keys():
+                tmpr['comment'] = tcdj['comment']
+            else:
+                tmpr['comment'] = ""
+            tcases[ tck ]['lastResult'] = tmpr
+    #print(" -")
+
+    fsum = open("summary.tex", 'w')
+    print('\\newpage\n\\section{Summary Information}', file=fsum)    
+    print('\\begin{longtable}{ll}\n\\toprule', file=fsum)
+    print(f"Number of Requirements: & {{nr}} \\\\".format(nr=len(reqs)), file=fsum)
+    print(f"Number of Verification Elements: & {{ne}} \\\\".format(ne=len(velem)), file=fsum)
+    print(f"Number of Test Cases: & {{ntc}} \\\\".format(ntc=len(tcases)), file=fsum)
+    print('\\bottomrule\n\\end{longtable}', file=fsum)
+    fsum.close()
+
+    fout = open(fname, 'w')
+
+    print('\\section{VCD}', file=fout)    
+    print('\\afterpage{', file=fout)
+    #print('\\begin{landscape}\n', file=fout)
+    #print('% Ugly hack for centering on page\n\\null\n\\vspace{1.0cm}', file=fout)
+
+    print('{\small', file=fout)
+    print('\\newlength{\\LTcapwidthold}', file=fout)
+    print('\\setlength{\\LTcapwidthold}{\\LTcapwidth}', file=fout)
+    print('\\setlength{\\LTcapwidth}{\\textheight}', file=fout)
+
+    print('\\begin{longtable}{lllll}', file=fout)
+    print('\\caption{', file=fout)
+    print('VCD Table.}', file=fout)
+    print('\\label{tab:dmvcd}', file=fout)
+
+    print('\\\\\n\\toprule', file=fout)
+    print('\\textbf{Requirement} & \\textbf{Verification Element} & \\textbf{Test Case} & \\textbf{Last Run} & \\textbf{Test Status} \\\\\n',
+          file=fout)
+    print('\\toprule\n\\endhead', file=fout)
+
+    for req in reqs.keys():
+        print("\\begin{tabular}{@{}l@{}}", req, "\\\\ {\\footnotesize ", reqs[req]['reqDoc'], "}\end{tabular} &", file=fout)
+        #print(f"{{req}} ({{doc}})".format(req=req,doc=reqs[req]['reqDoc']))
+        nve = len(reqs[req]['VEs'])
+        i = 0
+        for ve in reqs[req]['VEs']:
+            i = i + 1
+            if i == 1:
+                print("\\begin{tabular}{@{}l@{}}", ve, "\\\\ \\vcdJiraRef{", velem[ve]['key'], "}\end{tabular} &", file=fout)
+            else:
+                print(" & \\begin{tabular}{@{}l@{}}",ve,"\\\\ \\vcdJiraRef{", velem[ve]['key'], "}\end{tabular} &", file=fout)
+                #print(f"& {{ve}} &".format(ve=ve), file=fout)
+            #print(f"  > {{ve}} ({{lvv}})".format(ve=ve,lvv=velem[ve]['key']))
+            ntc = len(velem[ve]['tc'])
+            if ntc == 0:
+                print(" && \\\\", file = fout)
+            else:
+                l = 0
+                for tc in velem[ve]['tc']:
+                    l = l + 1
+                    if l == 1:
+                        print("\\begin{tabular}{@{}l@{}}", tc, "\\\\ {\\footnotesize ", tcases[tc]['tspec'], "}\end{tabular} &", file=fout)
+                    else:
+                        print(" && \\begin{tabular}{@{}l@{}}", tc, " \\\\ {\\footnotesize", tcases[tc]['tspec'], "}\end{tabular} &", file=fout)
+                        #print(f" && {{tc}} &".format(tc=tc), file=fout)
+                    print(f"    _ {{tc}}({{tcs}}) in {{tspec}} test specification".format(tc=tc,tcs=tcases[tc]['status'],tspec=tcases[tc]['tspec']))
+                    if 'lastResult' in tcases[tc].keys():
+                        print(f" {{date}} & \\{{result}} \\\\".format(date=tcases[tc]['lastResult']['date'],result=tcases[tc]['lastResult']['status']),
+                              file=fout)
+                        print(f"       Execution date {{date}}  result: {{result}}".format(date=tcases[tc]['lastResult']['date'],result=tcases[tc]['lastResult']['status']))
+                    else:
+                        print(" & \\notexec{} \\\\", file=fout)
+                        print("        Not run")
+                    if l != ntc:
+                        print("\\cmidrule{3-5}", file=fout)
+            if i != nve:
+                print("\\cmidrule{2-5}", file=fout)
+        print("\\midrule", file=fout)
+
+    print('\\end{longtable}{lllll}', file=fout)
+    print('\\setlength{\\LTcapwidth}{\\LTcapwidthold}', file=fout)
+    #print('\\end{landscape}', file=fout)
+    print('}\n}', file=fout)
+    fout.close()

--- a/docsteady/vcd.py
+++ b/docsteady/vcd.py
@@ -475,7 +475,7 @@ def summary(jc, VEs, reqs, comp):
     # get TC result
 
     fsum = open(comp.lower() +"_summary.tex", 'w')
-    print('\\newpage\n\\section{Summary Information}', file=fsum)
+    print('\\newpage\n\\section{Summary Information}\\label{sec:summary}', file=fsum)
 
     #print('\\begin{longtable}{ll}\n\\toprule', file=fsum)
     print('\\begin{longtable}{rccc}\n\\toprule', file=fsum)
@@ -506,7 +506,7 @@ def printVCD(VEs, reqs, comp):
 
     fname = comp.lower() + "_vcd.tex"
     fout = open(fname, 'w')
-    print('\\section{VCD}', file=fout)
+    print('\\section{VCD}\\label{sec:vcd}', file=fout)
     print('\\afterpage{', file=fout)
     print('{\\small', file=fout)
     print('\\newlength{\\LTcapwidthold}', file=fout)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ requires = [
     'click',
     'BeautifulSoup4',
     'marshmallow<3',
-    'setuptools_scm'
+    'setuptools_scm',
+    'pymysql',
 ]
 
 doc_requires = [


### PR DESCRIPTION
The code to generate VCD is ready to be reviewed. 
There are procedures to generate the VCD using the REST APIs, that are not reliable, slow and also a bit disorganized (could be optimized).
In many cases, these are missing relations and therefore a different set of procedures has been derived, in order to produce the VCD quiring directly the CB, much quicker and reliable. LDM-692 has been derived going directly to the DB.