### PR TITLE
U/gcomoretto/img an dfixes

### DIFF
--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -101,6 +101,8 @@ def generate_spec(format, username, password, folder, path):
     requirements_to_testcases = OrderedDict(sorted(Config.REQUIREMENTS_TO_TESTCASES.items(),
                                                    key=lambda item: alphanum_key(item[0])))
 
+    for testcase in Config.CACHED_LIBTESTCASES.keys():
+        print(testcase)
 
 
     env = Environment(loader=ChoiceLoader([
@@ -122,7 +124,9 @@ def generate_spec(format, username, password, folder, path):
     metadata["folder"] = folder
     metadata["template"] = template.filename
     text = template.render(metadata=metadata,
-                           testcases=testcases,
+                           testcases=testcases['active'],
+                           deprecated=testcases['deprecated'],
+                           libtestcases=Config.CACHED_LIBTESTCASES.values(),
                            requirements_to_testcases=requirements_to_testcases,
                            requirements_map=requirements,
                            testcases_map=Config.CACHED_TESTCASES)

--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -89,7 +89,7 @@ def generate_spec(format, username, password, folder, path):
 
     # Build model
     try:
-        testcases = build_spec_model(folder)
+        testcases, requirements = build_spec_model(folder)
     except Exception as e:
         print("Error in building model")
         print(e)
@@ -100,6 +100,8 @@ def generate_spec(format, username, password, folder, path):
     # Sort the dictionary
     requirements_to_testcases = OrderedDict(sorted(Config.REQUIREMENTS_TO_TESTCASES.items(),
                                                    key=lambda item: alphanum_key(item[0])))
+
+
 
     env = Environment(loader=ChoiceLoader([
         FileSystemLoader(Config.TEMPLATE_DIRECTORY),
@@ -122,7 +124,7 @@ def generate_spec(format, username, password, folder, path):
     text = template.render(metadata=metadata,
                            testcases=testcases,
                            requirements_to_testcases=requirements_to_testcases,
-                           requirements_map=Config.CACHED_REQUIREMENTS,
+                           requirements_map=requirements,
                            testcases_map=Config.CACHED_TESTCASES)
 
     print(_as_output_format(text), file=file)
@@ -138,7 +140,7 @@ def generate_spec(format, username, password, folder, path):
         metadata=metadata,
         testcases=testcases,
         requirements_to_testcases=requirements_to_testcases,
-        requirements_map=Config.CACHED_REQUIREMENTS,
+        requirements_map=requirements,
         testcases_map=Config.CACHED_TESTCASES)
     print(_as_output_format(appendix_text), file=appendix_file)
 

--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -101,10 +101,6 @@ def generate_spec(format, username, password, folder, path):
     requirements_to_testcases = OrderedDict(sorted(Config.REQUIREMENTS_TO_TESTCASES.items(),
                                                    key=lambda item: alphanum_key(item[0])))
 
-    for testcase in Config.CACHED_LIBTESTCASES.keys():
-        print(testcase)
-
-
     env = Environment(loader=ChoiceLoader([
         FileSystemLoader(Config.TEMPLATE_DIRECTORY),
         PackageLoader('docsteady', 'templates')

--- a/docsteady/config.py
+++ b/docsteady/config.py
@@ -68,7 +68,7 @@ class Config:
     milestone_pattern_text = r"\b(" + "|".join(DOC_NAMES) + r")(-\d+-\d+)([\s\.])"
     MILESTONE_PATTERN = re.compile(milestone_pattern_text)
     DOWNLOAD_IMAGES = True
-    MAX_IMG_PIXELS = 600
+    MAX_IMG_PIXELS = 450
     MIN_IMG_PIXELS = 32
 
     coverage = [   # Coverage for requirements and verification elements

--- a/docsteady/config.py
+++ b/docsteady/config.py
@@ -51,6 +51,7 @@ class Config:
     DOC = pandoc.Document()
     OUTPUT_FORMAT = None
     CACHED_TESTCASES = {}
+    CACHED_LIBTESTCASES = {}
     CACHED_USERS = {}
     CACHED_REQUIREMENTS = {}  # type : Dict[str, Issue]
     CACHED_ISSUES = {}  # type : Dict[str, Issue]

--- a/docsteady/spec.py
+++ b/docsteady/spec.py
@@ -163,7 +163,8 @@ class TestCase(Schema):
         for teststep in teststeps:
             if teststep.get("test_case_key"):
                 test_case_for_key(teststep["test_case_key"])
-        return teststeps
+        teststeps_sorted = sorted(teststeps, key=lambda step: step["index"])
+        return teststeps_sorted
 
 
 def build_spec_model(folder):
@@ -189,6 +190,7 @@ def build_spec_model(folder):
     testcases_resp = resp.json()
     testcases_resp.sort(key=lambda tc: alphanum_key(tc["key"]))
     testcases = []
+    requirements = {}
     for testcase_resp in testcases_resp:
         testcase, errors = TestCase().load(testcase_resp)
         if errors:
@@ -196,8 +198,11 @@ def build_spec_model(folder):
         if testcase["key"] not in Config.CACHED_TESTCASES:
             Config.CACHED_TESTCASES["key"] = testcase
         testcases.append(testcase)
+        for req in testcase['requirements']:
+            if req['key'] not in requirements.keys():
+                requirements[req['key']] = req
 
     if max_tests == len(testcases):
         print("[WARNING]: Test case count same as max_tests", file=sys.stderr)
 
-    return testcases
+    return testcases, requirements

--- a/docsteady/spec.py
+++ b/docsteady/spec.py
@@ -162,7 +162,8 @@ class TestCase(Schema):
         # Prefetch any testcases we might need
         for teststep in teststeps:
             if teststep.get("test_case_key"):
-                test_case_for_key(teststep["test_case_key"])
+                step_testcase = test_case_for_key(teststep["test_case_key"])
+                Config.CACHED_LIBTESTCASES[step_testcase['key']] = step_testcase
         teststeps_sorted = sorted(teststeps, key=lambda step: step["index"])
         return teststeps_sorted
 
@@ -190,6 +191,7 @@ def build_spec_model(folder):
     testcases_resp = resp.json()
     testcases_resp.sort(key=lambda tc: alphanum_key(tc["key"]))
     testcases = []
+    deprecated = []
     requirements = {}
     for testcase_resp in testcases_resp:
         testcase, errors = TestCase().load(testcase_resp)
@@ -197,7 +199,10 @@ def build_spec_model(folder):
             raise Exception("Unable to process errors: " + str(errors))
         if testcase["key"] not in Config.CACHED_TESTCASES:
             Config.CACHED_TESTCASES["key"] = testcase
-        testcases.append(testcase)
+        if testcase['status'] == 'Deprecated':
+            deprecated.append(testcase)
+        else:
+            testcases.append(testcase)
         for req in testcase['requirements']:
             if req['key'] not in requirements.keys():
                 requirements[req['key']] = req
@@ -205,4 +210,8 @@ def build_spec_model(folder):
     if max_tests == len(testcases):
         print("[WARNING]: Test case count same as max_tests", file=sys.stderr)
 
-    return testcases, requirements
+    alltestcases = {}
+    alltestcases["active"] = testcases
+    alltestcases['deprecated'] = deprecated
+
+    return alltestcases, requirements

--- a/docsteady/templates/dm-spec.latex.jinja2
+++ b/docsteady/templates/dm-spec.latex.jinja2
@@ -32,7 +32,10 @@ Test Id & Test Name\tabularnewline
 
 \newpage
 
-\section{Test Cases}
+\section{Active Test Cases}
+
+This section documents all active test cases.
+
 {% for testcase in testcases %}
 
 \subsection{{ '{' }}{{ href(testcase.jira_url, testcase.key) }}
@@ -174,4 +177,99 @@ Version & Status & Priority & Verification Type & Owner
 {% endif %}
 {% endfor %}
 
+\newpage
+\section{Library Test Cases}
+
+This section includes all test cases that are used as library.
+
+{% if libtestcases|length > 0 %}
+
+{% for testcase in libtestcases %}
+
+\subsection{{ '{' }}{{ href(testcase.jira_url, testcase.key) }}
+    - {{ testcase.name }}{{ "}" }}{{ label(testcase.key.lower()) }}
+
+\begin{longtable}[]{llllll}
+\toprule
+Version & Status & Priority & Verification Type & Owner
+\\\midrule
+{{ testcase.version }} & {{ testcase.status }} & {{ testcase.priority }} &
+{{ testcase.verification_type }} & {{ testcase.owner }}
+\\\bottomrule
+\end{longtable}
+
+\subsubsection{Test Items}
+{% if testcase.objective %}
+{{ testcase.objective }}
+{% endif %}
+
+{% if testcase.more_objectives %}
+{% for title, objective in testcase.more_objectives.items() %}
+\paragraph{ {{ title.replace("_", " ").title() }} }
+{{ objective }}
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+
+{% else %}
+  \textit{No library test cases found.}
+{% endif %}
+
+
+
+
+\newpage
+\section{Deprecated Test Cases}
+
+This section includes all test cases that have been marked as deprecated.
+These test cases will never be executed again, but have been in the past.
+For this reason it is important to keep them in the baseline as a reference.
+
+{% if deprecated|length > 0 %}
+
+{% for testcase in deprecated %}
+
+\subsection{{ '{' }}{{ href(testcase.jira_url, testcase.key) }}
+    - {{ testcase.name }}{{ "}" }}{{ label(testcase.key.lower()) }}
+
+\begin{longtable}[]{llllll}
+\toprule
+Version & Status & Priority & Verification Type & Owner
+\\\midrule
+{{ testcase.version }} & {{ testcase.status }} & {{ testcase.priority }} &
+{{ testcase.verification_type }} & {{ testcase.owner }}
+\\\bottomrule
+\end{longtable}
+
+\subsubsection{Verification Elements}
+{% if testcase.requirements %}
+\begin{itemize}
+{% for item in testcase.requirements %}
+\item {{ href(item.jira_url, item.key) }} - {{ item.summary }}
+{% endfor %}
+\end{itemize}
+{% else %}
+    None.
+{% endif %}
+
+\subsubsection{Test Items}
+{% if testcase.objective %}
+{{ testcase.objective }}
+{% endif %}
+
+{% if testcase.more_objectives %}
+{% for title, objective in testcase.more_objectives.items() %}
+\paragraph{ {{ title.replace("_", " ").title() }} }
+{{ objective }}
+{% endfor %}
+{% endif %}
+
+{% endfor %}
+
+{% else %}
+  \textit{No deprecated test cases found.}
+{% endif %}
+
+\newpage
 \appendix

--- a/docsteady/templates/dm-spec.latex.jinja2
+++ b/docsteady/templates/dm-spec.latex.jinja2
@@ -34,7 +34,8 @@ Test Id & Test Name\tabularnewline
 
 \section{Active Test Cases}
 
-This section documents all active test cases.
+This section documents all active test cases that have a status in the Jira/ATM system of Draft, Defined or Approved.
+
 
 {% for testcase in testcases %}
 
@@ -178,9 +179,14 @@ Version & Status & Priority & Verification Type & Owner
 {% endfor %}
 
 \newpage
-\section{Library Test Cases}
+\section{Reusable Test Cases}
 
-This section includes all test cases that are used as library.
+Test cases in this section are made up of commonly encountered steps that have been factored out into modular, reusable scripts.
+These test cases are meant solely for the building of actual tests used for verification, to be inserted in test scripts via the “Call to Test” functionality in Jira/ATM.
+They streamline the process of writing test scripts by providing pre-designed steps, while also ensuring homogeneity throughout the test suite.
+These reusable modules are not themselves verifying requirements.
+Also, these test cases shall not call other reusable test cases in their script.
+
 
 {% if libtestcases|length > 0 %}
 

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -156,12 +156,15 @@ The following personnel are involved in this test activity:
 \begin{longtable}{p{0.12\textwidth}p{0.2\textwidth}p{0.56\textwidth}p{0.12\textwidth}}
 \toprule
 {% for cycle in testcycles %}
+
   \multicolumn{3}{c}{ Test Cycle {\bf {{ cycle.key }}: {{ cycle.name }} }} \\\hline
+
   {\bf \footnotesize test case} & {\bf \footnotesize status} & {\bf \footnotesize comment} & {\bf \footnotesize issues} \\\toprule
-  {% for test_result in testresults_map[cycle.key] %}
-    \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_result['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_result['test_case_key'] }}{{ '}' }} 
-    & {{ test_result['status'] }} & {{ test_result['comment'] }} &
-    {% for issue_key in test_result['result_issue_keys'] %}
+
+  {% for test_item in testcycles_map[cycle.key].test_items %}
+    \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_item['test_case_key'] }}{{ '}' }}
+    & {{ test_item['status'] }} & {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }} &
+    {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
       \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue_key }}{{ "}" }}{{ "{" }}{{ issue_key }}{{ "}" }}
     {% endfor %}
     \\\hline
@@ -221,31 +224,30 @@ Open test cycle {\it \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testrun/
 
   \subsubsection{Test Cases in {{ cycle.key }} Test Cycle}
 
-  {% for test_result in testresults_map[cycle.key] %}
+  {% for test_item in testcycles_map[cycle.key].test_items %}
 
-    \paragraph{Test Case {{ test_result['test_case_key'] }} }\mbox{}\\
+    \paragraph{Test Case {{ test_item['test_case_key'] }} - {{ testcases_map[ test_item['test_case_key'] ]['name'] }} }\mbox{}\\
 
-Open  \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_result['test_case_key'] }}}{\textit{ {{ test_result['test_case_key'] }} } }
+Open  \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}}{\textit{ {{ test_item['test_case_key'] }} } }
 test case in Jira.
 
-    {{  testcases_map[test_result['test_case_key']]['objective'] }}
+    {{  testcases_map[ test_item['test_case_key'] ]['objective'] }}
 
-    {\bf Preconditions}:\\
-    {{ testcases_map[test_result['test_case_key']]['precondition'] }}
+    \textbf{ Preconditions}:\\
+    {{ testcases_map[ test_item['test_case_key'] ]['precondition'] }}
 
-    Execution status: {\bf {{  test_result['status'] }} }
+    Execution status: {\bf {{  test_item['status'] }} }
 
-    Final comment:\\{{ test_result['comment'] }}
+    Final comment:\\{{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
 
-    {% if test_result['issues'] %}
-      Issues found during the execution of {{ test_result['test_case_key'] }} test case:
+    {% if testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
+      Issues found during the execution of {{ test_item['test_case_key'] }} test case:
 
       \begin{itemize}
-      {% for issue in test_result['issues'] %}
+      {% for issue in testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
         \item {{ issue['id'] }}: {{ issue['summary'] }}
       {% endfor %}
       \end{itemize}
-
     {% endif %}
 
     Detailed step results:
@@ -253,7 +255,7 @@ test case in Jira.
     \begin{longtable}{p{1cm}p{2cm}p{13cm}}
     \hline
     {Step} & \multicolumn{2}{c}{Description, Results and Status}\\ \hline
-    {% for script_result in test_result['script_results'] %}
+    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['script_results'] %}
       {{ loop.index }} & Description &
 
       \begin{minipage}[t]{13cm}{\footnotesize

--- a/docsteady/tplan.py
+++ b/docsteady/tplan.py
@@ -134,8 +134,10 @@ def build_tpr_model(tplan_id):
 
         resp = requests.get(Config.TESTRESULTS_URL.format(testrun=cycle_key), auth=Config.AUTH)
         resp.raise_for_status()
-        testresult, errors = TestResult().load(resp.json(), many=True)
-        test_results_map[cycle_key] = testresult
+        testresults, errors = TestResult().load(resp.json(), many=True)
+        test_results_map[cycle_key] = {}
+        for result in testresults:
+            test_results_map[cycle_key][result['test_case_key']] = result
 
         # Get all the test cases from the test items
         for test_item in test_cycle['test_items']:

--- a/docsteady/utils.py
+++ b/docsteady/utils.py
@@ -146,7 +146,9 @@ def download_and_rewrite_images(value):
     rest_location = urljoin(Config.JIRA_INSTANCE, "rest")
     for img in soup.find_all("img"):
         img_url = urljoin(rest_location, img["src"])
-        fs_path = urlparse(img_url).path[1:]
+        url_path = urlparse(img_url).path[1:]
+        img_name = os.path.basename(url_path)
+        fs_path = "jira_imgs/" + img_name
         if Config.DOWNLOAD_IMAGES:
             os.makedirs(dirname(fs_path), exist_ok=True)
             existing_files = os.listdir(dirname(fs_path))
@@ -170,7 +172,8 @@ def download_and_rewrite_images(value):
         im = Image.open(fs_path)
         width, height = im.size
         if width > Config.MAX_IMG_PIXELS:
-            print(f"[WARNING] Image {fs_path} width greater than {Config.MAX_IMG_PIXELS}")
+            print(f"[WARNING] Image {fs_path} width greater than {Config.MAX_IMG_PIXELS} pixels.")
+            img["width"] = f"{Config.MAX_IMG_PIXELS}px"
         if img.previous_element.name != "br":
             img.insert_before(soup.new_tag("br"))
         img["style"] = ""


### PR DESCRIPTION
With this implementation, I manage to regenerate LDM-540 and LSE-419, including images without any problem. The limit is 450 pixels and not 600.

I have also added a few improvements on the order of the test steps and in the test specification, and on the order of the test results in the test plan and report.

Finally, I have separated in the test spec the deprecated test cases and listed those test cases that are used in a test script.

I have still an improvement pending on the VCD (add verified by VEs in the summary), however, It would be good to have this in PiPy as soon as possible.