### PR TITLE
Test Plan and Report improvements

### DIFF
--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -189,17 +189,6 @@ def generate_report(format, username, password, plan, path):
     metadata["tplan"] = tplan
     metadata["template"] = template.filename
 
-    for cycle in list(testcycles_map.values()):
-        for test_item in testcycles_map[cycle['key']]['test_items']:
-            print(" - ", test_item)
-            print(testcases_map[test_item['test_case_key']]['test_script'])
-            for step in testcases_map[test_item['test_case_key']]['test_script']:
-                print(step)
-            for script_result in testresults_map[cycle['key']][test_item['test_case_key']]['script_results']:
-                print(script_result)
-                for key in script_result:
-                    print(key, script_result[key])
-
     text = template.render(metadata=metadata,
                            testplan=testplan,
                            testcycles=list(testcycles_map.values()),  # For convenience (sorted)

--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -189,6 +189,17 @@ def generate_report(format, username, password, plan, path):
     metadata["tplan"] = tplan
     metadata["template"] = template.filename
 
+    for cycle in list(testcycles_map.values()):
+        for test_item in testcycles_map[cycle['key']]['test_items']:
+            print(" - ", test_item)
+            print(testcases_map[test_item['test_case_key']]['test_script'])
+            for step in testcases_map[test_item['test_case_key']]['test_script']:
+                print(step)
+            for script_result in testresults_map[cycle['key']][test_item['test_case_key']]['script_results']:
+                print(script_result)
+                for key in script_result:
+                    print(key, script_result[key])
+
     text = template.render(metadata=metadata,
                            testplan=testplan,
                            testcycles=list(testcycles_map.values()),  # For convenience (sorted)

--- a/docsteady/cycle.py
+++ b/docsteady/cycle.py
@@ -84,6 +84,20 @@ class ScriptResult(Schema):
     # result_issue_keys are actually jira issue keys (not HTTP links)
     result_issue_keys = fields.List(fields.String(), load_from="issueLinks")
     result_issues = fields.Nested(Issue, many=True)
+    custom_field_values = fields.List(fields.Dict(), load_from="customFieldValues")
+
+    # Custom fields
+    example_code = MarkdownableHtmlPandocField()  # name: "Example Code"
+
+    @pre_load(pass_many=False)
+    def extract_custom_fields(self, data):
+        # Custom fields
+        custom_field_values = data.get("customFieldValues", list())
+        for custom_field in custom_field_values:
+            string_value = custom_field["stringValue"]
+            name = custom_field["customField"]["name"]
+            name = name.lower().replace(" ", "_")
+            data[name] = string_value
 
     @post_load
     def postprocess(self, data):

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -275,7 +275,6 @@ test case in Jira.
 
       \begin{minipage}[t]{13cm}{\footnotesize
       {{ script_result.custom_field_values.example_code }}
-      {# {{ testcases_map[test_item['test_case_key']].test_script[{{ loop.index }}]['exmaple_code'] }} #}
       \vspace{\dp0}
       } \end{minipage} \\
       \\ \cdashline{2-3}

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -25,9 +25,9 @@
 
 \setDocCompact{true}
 
-\title[\milestoneId{}~Test Report]{\milestoneId{} (\milestoneName{})~Test Plan and Report}
+\title{ {{ testplan.milestone_id }} - {{ testplan.milestone_name }} - Test Plan and Report}
 \setDocRef{\lsstDocType-\lsstDocNum}
-\setDocDate{\vcsdate}
+\date{\vcsdate}
 \setDocUpstreamLocation{\url{https://github.com/lsst/lsst-texmf/examples}}
 \author{ {{ testplan['owner'] }} }
 
@@ -35,7 +35,7 @@
 
 
 \setDocAbstract{
-This is the test plan and report for \milestoneId{} (\milestoneName{}), an LSST level 2 milestone pertaining to the Data Management Subsystem.
+This is the test plan and report for {{ testplan.milestone_id }} ({{ testplan.milestone_name }}), an LSST level 2 milestone pertaining to the Data Management Subsystem.
 }
 
 
@@ -119,6 +119,7 @@ The current status of test plan {{ testplan['key'] }} in Jira is {{ testplan['st
   {{ testplan.pmcs_activity }}
 {% endif %}
 
+\newpage
 \section{Personnel}
 \label{sect:personnel}
 
@@ -269,7 +270,15 @@ test case in Jira.
       } \end{minipage} \\
       \\ \cdashline{2-3}
 
-      & Expected Result & 
+      & Example Code &
+
+      \begin{minipage}[t]{13cm}{\footnotesize
+      {{ testcases_map[test_case_key].test_script[{{ loop.index }}]['exmaple_code'] }}
+      \vspace{\dp0}
+      } \end{minipage} \\
+      \\ \cdashline{2-3}
+
+      & Expected Result &
 
       \begin{minipage}[t]{13cm}{\footnotesize
       {{ script_result['expected_result'] }}

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -25,7 +25,7 @@
 
 \setDocCompact{true}
 
-\title{ {{ testplan.milestone_id }} - {{ testplan.milestone_name }} - Test Plan and Report}
+\title{ {{ testplan.milestone_id }} {{ testplan.milestone_name }} Test Plan and Report}
 \setDocRef{\lsstDocType-\lsstDocNum}
 \date{\vcsdate}
 \setDocUpstreamLocation{\url{https://github.com/lsst/lsst-texmf/examples}}
@@ -81,7 +81,7 @@ Section \ref{sect:personnel} describes the necessary roles and lists the individ
 Section \ref{sect:overview} provides a summary of the test results, including an overview in Table \ref{table:summary}, an overall assessment statement and suggestions for possible improvements.
 Section \ref{sect:detailedtestresults} provides detailed results for each step in each test case.
 
-The current status of test plan {{ testplan['key'] }} in Jira is {{ testplan['status'] }}.
+The current status of test plan {{ testplan['key'] }} in Jira is \textbf{ {{ testplan['status'] }} }.
 
 \subsection{References}
 \label{sect:references}
@@ -270,13 +270,16 @@ test case in Jira.
       } \end{minipage} \\
       \\ \cdashline{2-3}
 
+      {% if 'example_code' in script_result.custom_field_values %}
       & Example Code &
 
       \begin{minipage}[t]{13cm}{\footnotesize
-      {{ testcases_map[test_case_key].test_script[{{ loop.index }}]['exmaple_code'] }}
+      {{ script_result.custom_field_values.example_code }}
+      {# {{ testcases_map[test_item['test_case_key']].test_script[{{ loop.index }}]['exmaple_code'] }} #}
       \vspace{\dp0}
       } \end{minipage} \\
       \\ \cdashline{2-3}
+      {% endif %}
 
       & Expected Result &
 

--- a/docsteady/tplan.py
+++ b/docsteady/tplan.py
@@ -32,7 +32,9 @@ from .config import Config
 
 class TestPlan(Schema):
     key = fields.String(required=True)
-    name = fields.String(required=True)
+    # the name (TPR title) can contain extra characters that requires pandoc.
+    # this may break the bib reference generation
+    name = HtmlPandocField(required=True)
     objective = SubsectionableHtmlPandocField(extractable=["scope"])
     status = fields.String(required=True)
     folder = fields.String(required=True)

--- a/docsteady/tplan.py
+++ b/docsteady/tplan.py
@@ -106,7 +106,7 @@ class TestPlan(Schema):
             data['milestone_name'] = data['name'].replace(sname[0], '').strip()
         else:
             data['milestone_id'] = data['key']
-            data['milestone_name'] = data['name'].capitalize()
+            data['milestone_name'] = data['name'].title()
 
         # Product
         data['product'] = data['folder'].split('/')[-1]


### PR DESCRIPTION
python:
- added custom fields to the test results class (to extract Example Code custom field)
- use pandoc for LVV-P name
- use .title() instead of .capitalize() to get the document title from the LVV-P name
template
- removed from the title round brackets
- removed latex macros from the title
- use \date instead of \setDocDate
- LVV-P status now in bold
- added \newpage before all \section
- added Example Code to the detailed results script
