### PR TITLE
Tickets/dm 22425 plus fixes

### DIFF
--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -201,26 +201,6 @@ def generate_report(format, username, password, trace, plan, path):
     file = open(path, "w") if path else sys.stdout
     print(_as_output_format(text), file=file or sys.stdout)
 
-    # Will exit if it can't find a template
-    appendix_template = _try_appendix_template(target, env)
-    if not appendix_template:
-        click.echo(f"No Appendix Template Found, skipping...", err=True)
-        sys.exit(0)
-
-    metadata["template"] = appendix_template.filename
-    appendix_file = _get_appendix_output(path)
-
-    appendix_text = appendix_template.render(
-        metadata=metadata,
-        testplan=testplan,
-        testcycles=list(testcycles_map.values()),  # For convenience (sorted by item key)
-        testcycles_map=testcycles_map,
-        testresults=list(testresults_map.values()),  # For convenience (sorted by item key)
-        testresults_map=testresults_map,
-        testcases_map=testcases_map)
-
-    print(_as_output_format(appendix_text), file=appendix_file)
-
     if trace:
         # Will exit if it can't find a template
         appendix_template = _try_appendix_template(target, env)

--- a/docsteady/__init__.py
+++ b/docsteady/__init__.py
@@ -150,9 +150,10 @@ def generate_spec(format, username, password, folder, path):
 @click.option('--username', prompt="Jira Username", envvar="JIRA_USER", help="Jira username")
 @click.option('--password', prompt="Jira Password", hide_input=True,
               envvar="JIRA_PASSWORD", help="Jira Password")
+@click.option('--trace', default=False, help='If true, traceability table will be added in appendix')
 @click.argument('plan')
 @click.argument('path', required=False, type=click.Path())
-def generate_report(format, username, password, plan, path):
+def generate_report(format, username, password, trace, plan, path):
     """Read in a Test Plan and related cycles from Adaptavist Test management.
     If specified, PATH is the resulting output.
     """
@@ -219,6 +220,19 @@ def generate_report(format, username, password, plan, path):
         testcases_map=testcases_map)
 
     print(_as_output_format(appendix_text), file=appendix_file)
+
+    if trace:
+        # Will exit if it can't find a template
+        appendix_template = _try_appendix_template(target, env)
+        if not appendix_template:
+            click.echo(f"No Appendix Template Found, skipping...", err=True)
+            sys.exit(0)
+        metadata["template"] = appendix_template.filename
+        appendix_file = _get_appendix_output(path)
+        appendix_text = appendix_template.render(
+            metadata=metadata,
+            testcases_map=testcases_map)
+        print(_as_output_format(appendix_text), file=appendix_file)
 
 
 def _try_appendix_template(target, env):

--- a/docsteady/config.py
+++ b/docsteady/config.py
@@ -64,7 +64,7 @@ class Config:
     TEMPLATE_DIRECTORY = os.curdir
 
     # Regexes for LSST things
-    DOC_NAMES = ['LDM', 'LSE', 'DMTN', 'DMTR', 'TSS', 'LPM']
+    DOC_NAMES = ['LDM', 'LSE', 'DMTN', 'DMTR', 'TSS', 'LPM', 'LTS']
     doc_pattern_text = r"\b(" + "|".join(DOC_NAMES) + r")(-\d+)\b(?!-)"
     DOCUSHARE_DOC_PATTERN = re.compile(doc_pattern_text)
     milestone_pattern_text = r"\b(" + "|".join(DOC_NAMES) + r")(-\d+-\d+)([\s\.])"

--- a/docsteady/cycle.py
+++ b/docsteady/cycle.py
@@ -149,7 +149,7 @@ class TestResult(Schema):
         # Need to do this here because we need result_issue_keys _and_ key
         data['issues'] = self.process_issues(data)
         # Force Sort script results after loading
-        data['script_results'] = sorted(data["script_results"], key=lambda i: i["index"])
+        data['script_results'] = sorted(data["script_results"], key=lambda step: step["index"])
         return data
 
     def process_issues(self, data):

--- a/docsteady/cycle.py
+++ b/docsteady/cycle.py
@@ -36,6 +36,7 @@ class TestCycleItem(Schema):
                                     load_from='testCaseKey', required=True)
     user_id = fields.String(load_from="userKey")
     user = fields.Function(load_from="userKey", deserialize=lambda obj: owner_for_id(obj))
+    assignee = fields.Function(load_from="assignedTo", deserialize=lambda obj: owner_for_id(obj))
     execution_date = fields.Function(deserialize=lambda o: as_arrow(o['executionDate']))
     status = fields.String(required=True)
 

--- a/docsteady/cycle.py
+++ b/docsteady/cycle.py
@@ -82,6 +82,7 @@ class ScriptResult(Schema):
     description = MarkdownableHtmlPandocField(load_from='description')
     comment = MarkdownableHtmlPandocField(load_from='comment')
     status = fields.String(load_from='status')
+    testdata = MarkdownableHtmlPandocField(load_from='testData')
     # result_issue_keys are actually jira issue keys (not HTTP links)
     result_issue_keys = fields.List(fields.String(), load_from="issueLinks")
     result_issues = fields.Nested(Issue, many=True)

--- a/docsteady/templates/dm-tpr-appendix.latex.jinja2
+++ b/docsteady/templates/dm-tpr-appendix.latex.jinja2
@@ -1,0 +1,17 @@
+\section{Traceability}
+
+\begin{longtable}{p{3cm}p{3cm}p{9cm}}
+\hline
+\textbf{Test Case} & \textbf{VE Key} & \textbf{VE Summary} \\ \hline
+{% for testcase in testcases_map %}
+  \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ testcase }}{{ '}' }}{{ '{' }}{{ testcase }}{{ '}' }} &
+{% for lvv in testcases_map[testcase]['requirements'] %}
+    {% if loop.index != 1 %}
+      &
+    {% endif %}
+  \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ lvv['key'] }}{{ "}" }}{{ "{" }}{{ lvv['key'] }}{{ "}" }}
+  & {{ lvv['summary'] }} \\ \cdashline{2-3}
+{% endfor %}
+\hline
+{% endfor %}
+\end{longtable}

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -169,8 +169,13 @@ The following personnel are involved in this test activity:
 
   {% for test_item in testcycles_map[cycle.key].test_items %}
     \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_item['test_case_key'] }}{{ '}' }}
-    & {{ test_item['status'] }} & {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }} &
-    {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
+    & {{ test_item['status'] }} &
+    \begin{minipage}[]{0.56\textwidth}
+    \smallskip
+    {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
+    \medskip
+    \end{minipage}
+    & {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
       \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue_key }}{{ "}" }}{{ "{" }}{{ issue_key }}{{ "}" }}
     {% endfor %}
     \\\hline

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -17,6 +17,8 @@
 \providecommand{\tightlist}{
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
+\setcounter{tocdepth}{4}
+
 \begin{document}
 
 \def\milestoneName{{ '{' }}{{ testplan.milestone_name }}{{ '}' }}
@@ -159,24 +161,25 @@ The personnel involved in the test campaign is shown in the following table.
 
 \newpage
 
-\section{Overview of the Test Results}
+\section{Test Campaign Overview}
 \label{sect:overview}
 
 \subsection{Summary}
 \label{sect:summarytable}
 
-\begin{longtable}{p{0.12\textwidth}p{0.2\textwidth}p{0.56\textwidth}p{0.12\textwidth}}
+\begin{longtable}{p{2cm}p{2.5cm}p{9cm}p{2.5cm}}
 \toprule
+\multicolumn{3}{l}{ Test Plan {\bf {{ testplan['key'] }}: {{ testplan['name'] }} }} & {{ testplan['status'] }} \\\hline
 {% for cycle in testcycles %}
 
-  \multicolumn{3}{c}{ Test Cycle {\bf {{ cycle.key }}: {{ cycle.name }} }} \\\hline
+  \multicolumn{3}{l}{ Test Cycle {\bf {{ cycle.key }}: {{ cycle.name }} }} & {{ cycle.status }} \\\hline
 
   {\bf \footnotesize test case} & {\bf \footnotesize status} & {\bf \footnotesize comment} & {\bf \footnotesize issues} \\\toprule
 
   {% for test_item in testcycles_map[cycle.key].test_items %}
     \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_item['test_case_key'] }}{{ '}' }}
     & {{ test_item['status'] }} &
-    \begin{minipage}[]{0.56\textwidth}
+    \begin{minipage}[]{9cm}
     \smallskip
     {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
     \medskip
@@ -195,7 +198,6 @@ The personnel involved in the test campaign is shown in the following table.
     \\\hline
   {% endfor %}
 {% endfor %}
-
 \caption{Test Results Summary}
 \label{table:summary}
 \end{longtable}
@@ -223,112 +225,116 @@ Not yet available.
 \label{sect:detailedtestresults}
 
 {% for cycle in testcycles %}
-
-  \subsection{Test Cycle {{ cycle.key }} }
+\subsection{Test Cycle {{ cycle.key }} }
 
 Open test cycle {\it \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testrun/{{ cycle.key }}}{{ '{' }}{{ cycle.name }}{{ '}' }}} in Jira.
 
-  {{ cycle.name }}\\
-  Status: {{cycle.status }}
+{{ cycle.name }}\\
+Status: {{ cycle.status }}
 
-  {{ cycle.description }}
+{{ cycle.description }}
 
-  \subsubsection{Software Version/Baseline}
+\subsubsection{Software Version/Baseline}
   {% if cycle.software_version %}
-    {{cycle.software_version}}
+{{cycle.software_version}}
   {% else %}
-    Not provided.
+Not provided.
   {% endif %}
 
-  \subsubsection{Configuration}
+\subsubsection{Configuration}
   {% if cycle.configuration %}
-    {{ cycle.configuration }}
+{{ cycle.configuration }}
   {% else %}
-    Not provided.
+Not provided.
   {% endif %}
 
-  \subsubsection{Test Cases in {{ cycle.key }} Test Cycle}
+\subsubsection{Test Cases in {{ cycle.key }} Test Cycle}
 
   {% for test_item in testcycles_map[cycle.key].test_items %}
-
-    \paragraph{Test Case {{ test_item['test_case_key'] }} - {{ testcases_map[ test_item['test_case_key'] ]['name'] }} }\mbox{}\\
+\paragraph{Test Case {{ test_item['test_case_key'] }} - {{ testcases_map[ test_item['test_case_key'] ]['name'] }} }\mbox{}\\
 
 Open  \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}}{\textit{ {{ test_item['test_case_key'] }} } }
 test case in Jira.
 
-    {{  testcases_map[ test_item['test_case_key'] ]['objective'] }}
+{{  testcases_map[ test_item['test_case_key'] ]['objective'] }}
 
-    \textbf{ Preconditions}:\\
-    {{ testcases_map[ test_item['test_case_key'] ]['precondition'] }}
+\textbf{ Preconditions}:\\
+{{ testcases_map[ test_item['test_case_key'] ]['precondition'] }}
 
-    Execution status: {\bf {{  test_item['status'] }} }
+Execution status: {\bf {{  test_item['status'] }} }
 
-    Final comment:\\{{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
+Final comment:\\{{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
 
     {% if testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
-      Issues found during the execution of {{ test_item['test_case_key'] }} test case:
+Issues found during the execution of {{ test_item['test_case_key'] }} test case:
 
-      \begin{itemize}
+\begin{itemize}
       {% for issue in testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
-        \item {{ issue['id'] }}: {{ issue['summary'] }}
+\item \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
       {% endfor %}
-      \end{itemize}
+\end{itemize}
     {% endif %}
 
-    Detailed step results:
+Detailed steps results:
 
-    \begin{longtable}{p{1cm}p{2cm}p{13cm}}
-    \hline
-    {Step} & \multicolumn{2}{c}{Description, Results and Status}\\ \hline
+\begin{longtable}{p{1cm}p{15cm}}
+\hline
+{Step} & Step Details\\ \hline
     {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['sorted'] %}
-      {{ loop.index }} & Description &
-
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result['description'] }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
+{{ loop.index }} & Description \\
+ & \begin{minipage}[t]{15cm}
+{\footnotesize
+\smallskip
+{{ script_result['description'] }}
+\medskip }
+\end{minipage}
+\\ \cdashline{2-2}
 
       {% if 'example_code' in script_result.custom_field_values %}
-      & Example Code &
-
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result.custom_field_values.example_code }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
+ & Example Code \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result.custom_field_values.example_code }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
+      {% endif %}
+      {% if script_result['testdata'] %}
+ & Test Data \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result['testdata'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
       {% endif %}
 
-      & Expected Result &
+ & Expected Result \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result['expected_result'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
 
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result['expected_result'] }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
-
-      & \begin{minipage}[t]{2cm}{Actual\\ Result}\end{minipage}   & 
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result['comment'] }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
+ & Actual Result \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result['comment'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
 
       {% if script_result['result_issues'] %}
-        & Issues        &
-        \begin{minipage}[t]{13cm}{\footnotesize
+ & Issues found executing this step:  \\
+ & \begin{minipage}[t]{13cm}{\footnotesize
+\smallskip
         {% for issue in script_result['result_issues'] %}
-          \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
+\href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
         {% endfor %}
-        \vspace{\dp0}
-        } \end{minipage} \\
-        \\ \cdashline{2-3}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
       {% endif %}
-
-      & Status          & {{ script_result['status'] }} \\ \hline
+ & Status: \textbf{ {{ script_result['status'] }} } \\ \hline
 
     {% endfor %}
-    \end{longtable}
+\end{longtable}
 
   {% endfor %}
 {% endfor %}

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -123,33 +123,30 @@ The current status of test plan {{ testplan['key'] }} in Jira is \textbf{ {{ tes
 \section{Personnel}
 \label{sect:personnel}
 
-The following personnel are involved in this test activity:
+The personnel involved in the test campaign is shown in the following table.
 
-\begin{itemize}
-\item Test Plan ({{ testplan.key }}) owner: {{ testplan.owner }}
-\item Test Cycles:
-\begin{itemize}
+\begin{longtable}{p{3cm}p{3cm}p{3cm}p{6cm}}
+\hline
+\multicolumn{2}{r}{Test Plan ({{ testplan.key }}) owner:} &
+\multicolumn{2}{l}{\textbf{ {{ testplan.owner }} } }\\\hline
 {% for cycle in testcycles %}
-  \item {{ cycle.key }} owner: 
+\multicolumn{2}{r}{ {{ cycle.key }} owner:} &
+\multicolumn{2}{l}{\textbf{
   {% if cycle.owner %}
     {{ cycle.owner }}
   {% else %}
     Undefined
   {% endif %}
-  \begin{itemize}
+}
+} \\\hline
+\textbf{Test Case} & \textbf{Assigned to} & \textbf{Executed by} & \textbf{Additional Test Personnel} \\ \hline
   {% for test_item in cycle.test_items %}
-    \item Test case \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item.test_case_key }}{{ '}' }}{{ '{' }}{{ test_item.test_case_key }}{{ '}' }} tester: {{ test_item.user }}
+\href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item.test_case_key }}{{ '}' }}{{ '{' }}{{ test_item.test_case_key }}{{ '}' }}
+& {\small {{ test_item.assignee }} } & {\small {{ test_item.user }} } &
+{\small {{ testcases_map[test_item.test_case_key].test_personnel }} } \\ \hline
   {% endfor %}
-  \end{itemize}
 {% endfor %}
-\end{itemize}
-\item Additional Test Personnel involved:
-  \begin{itemize}
-  {% for testcase in testcases_map %}
-    \item Test case \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ testcase }}{{ '}' }}{{ '{' }}{{ testcase }}{{ '}' }}: {{ testcases_map[testcase].test_personnel }}
-  {% endfor %}
-  \end{itemize}
-\end{itemize}
+\end{longtable}
 
 \newpage
 

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -35,7 +35,8 @@
 
 
 \setDocAbstract{
-This is the test plan and report for {{ testplan.milestone_id }} ({{ testplan.milestone_name }}), an LSST level 2 milestone pertaining to the Data Management Subsystem.
+This is the test plan and report for {{ testplan.milestone_id }} ({{ testplan.milestone_name }}),
+an LSST level 2 milestone pertaining to the Data Management Subsystem.
 }
 
 
@@ -73,12 +74,15 @@ This document was generated from Jira, obtaining the relevant information from t
 {% endfor %}
 ).
 
-Section \ref{sect:intro} provides an overview of the test campaign, the system under test (\product{}), the applicable documentation, and explains how this document is organized.
+Section \ref{sect:intro} provides an overview of the test campaign, the system under test (\product{}),
+the applicable documentation, and explains how this document is organized.
 Section \ref{sect:configuration}  describes the configuration used for this test.
 Section \ref{sect:personnel} describes the necessary roles and lists the individuals assigned to them.
-%Section \ref{sect:plannedtestactivities} provides the list of planned test cycles and test cases, including all relevant information that fully describes the test campaign.
+%Section \ref{sect:plannedtestactivities} provides the list of planned test cycles and test cases,
+including all relevant information that fully describes the test campaign.
 
-Section \ref{sect:overview} provides a summary of the test results, including an overview in Table \ref{table:summary}, an overall assessment statement and suggestions for possible improvements.
+Section \ref{sect:overview} provides a summary of the test results, including an overview in Table \ref{table:summary},
+an overall assessment statement and suggestions for possible improvements.
 Section \ref{sect:detailedtestresults} provides detailed results for each step in each test case.
 
 The current status of test plan {{ testplan['key'] }} in Jira is \textbf{ {{ testplan['status'] }} }.
@@ -143,7 +147,12 @@ The personnel involved in the test campaign is shown in the following table.
   {% for test_item in cycle.test_items %}
 \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item.test_case_key }}{{ '}' }}{{ '{' }}{{ test_item.test_case_key }}{{ '}' }}
 & {\small {{ test_item.assignee }} } & {\small {{ test_item.user }} } &
-{\small {{ testcases_map[test_item.test_case_key].test_personnel }} } \\ \hline
+\begin{minipage}[]{6cm}
+\smallskip
+{\small {{ testcases_map[test_item.test_case_key].test_personnel }} }
+\medskip
+\end{minipage}
+\\ \hline
   {% endfor %}
 {% endfor %}
 \end{longtable}

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -129,7 +129,7 @@ The current status of test plan {{ testplan['key'] }} in Jira is \textbf{ {{ tes
 \section{Personnel}
 \label{sect:personnel}
 
-The personnel involved in the test campaign is shown in the following table.
+The personnel involved in the test campaign are shown in the following table.
 
 \begin{longtable}{p{3cm}p{3cm}p{3cm}p{6cm}}
 \hline

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -181,8 +181,16 @@ The personnel involved in the test campaign is shown in the following table.
     {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
     \medskip
     \end{minipage}
-    & {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
+    &
+    {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
       \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue_key }}{{ "}" }}{{ "{" }}{{ issue_key }}{{ "}" }}
+    {% endfor %}
+    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['script_results'] %}
+      {% if script_result['result_issues'] %}
+        {% for issue in script_result['result_issues'] %}
+          \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}
+        {% endfor %}
+      {% endif %}
     {% endfor %}
     \\\hline
   {% endfor %}
@@ -272,7 +280,7 @@ test case in Jira.
     \begin{longtable}{p{1cm}p{2cm}p{13cm}}
     \hline
     {Step} & \multicolumn{2}{c}{Description, Results and Status}\\ \hline
-    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['script_results'] %}
+    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['sorted'] %}
       {{ loop.index }} & Description &
 
       \begin{minipage}[t]{13cm}{\footnotesize

--- a/docsteady/templates/dm-tpr.latex.jinja2
+++ b/docsteady/templates/dm-tpr.latex.jinja2
@@ -177,7 +177,7 @@ The personnel involved in the test campaign is shown in the following table.
   {\bf \footnotesize test case} & {\bf \footnotesize status} & {\bf \footnotesize comment} & {\bf \footnotesize issues} \\\toprule
 
   {% for test_item in testcycles_map[cycle.key].test_items %}
-    \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_item['test_case_key'] }}{{ '}' }}
+\href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_item['test_case_key'] }}{{ '}' }}
     & {{ test_item['status'] }} &
     \begin{minipage}[]{9cm}
     \smallskip
@@ -198,7 +198,7 @@ The personnel involved in the test campaign is shown in the following table.
     \\\hline
   {% endfor %}
 {% endfor %}
-\caption{Test Results Summary}
+\caption{Test Campaign Summary}
 \label{table:summary}
 \end{longtable}
 
@@ -284,7 +284,6 @@ Detailed steps results:
 {{ loop.index }} & Description \\
  & \begin{minipage}[t]{15cm}
 {\footnotesize
-\smallskip
 {{ script_result['description'] }}
 \medskip }
 \end{minipage}
@@ -293,7 +292,6 @@ Detailed steps results:
       {% if 'example_code' in script_result.custom_field_values %}
  & Example Code \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result.custom_field_values.example_code }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
@@ -301,22 +299,26 @@ Detailed steps results:
       {% if script_result['testdata'] %}
  & Test Data \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result['testdata'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
+      {% endif %}
+      {% if script_result['example_code'] %}
+ & Example Code \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+{{ script_result['example_code'] }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
       {% endif %}
 
  & Expected Result \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result['expected_result'] }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
 
  & Actual Result \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result['comment'] }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
@@ -324,7 +326,6 @@ Detailed steps results:
       {% if script_result['result_issues'] %}
  & Issues found executing this step:  \\
  & \begin{minipage}[t]{13cm}{\footnotesize
-\smallskip
         {% for issue in script_result['result_issues'] %}
 \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
         {% endfor %}

--- a/docsteady/templates/se-tpr.latex.jinja2
+++ b/docsteady/templates/se-tpr.latex.jinja2
@@ -195,7 +195,7 @@ The personnel involved in the test campaign is shown in the following table.
     \\\hline
   {% endfor %}
 {% endfor %}
-\caption{Test Results Summary}
+\caption{Test Campaign Summary}
 \label{table:summary}
 \end{longtable}
 
@@ -281,7 +281,6 @@ Detailed steps results:
 {{ loop.index }} & Description \\
  & \begin{minipage}[t]{15cm}
 {\footnotesize
-\smallskip
 {{ script_result['description'] }}
 \medskip }
 \end{minipage}
@@ -290,7 +289,6 @@ Detailed steps results:
       {% if 'example_code' in script_result.custom_field_values %}
  & Example Code \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result.custom_field_values.example_code }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
@@ -298,22 +296,26 @@ Detailed steps results:
       {% if script_result['testdata'] %}
  & Test Data \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result['testdata'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
+      {% endif %}
+      {% if script_result['example_code'] %}
+ & Example Code \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+{{ script_result['example_code'] }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
       {% endif %}
 
  & Expected Result \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result['expected_result'] }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
 
  & Actual Result \\
  & \begin{minipage}[t]{15cm}{\footnotesize
-\smallskip
 {{ script_result['comment'] }}
 \medskip }
 \end{minipage} \\ \cdashline{2-2}
@@ -321,7 +323,6 @@ Detailed steps results:
       {% if script_result['result_issues'] %}
  & Issues found executing this step:  \\
  & \begin{minipage}[t]{13cm}{\footnotesize
-\smallskip
         {% for issue in script_result['result_issues'] %}
 \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
         {% endfor %}

--- a/docsteady/templates/se-tpr.latex.jinja2
+++ b/docsteady/templates/se-tpr.latex.jinja2
@@ -178,8 +178,16 @@ The personnel involved in the test campaign is shown in the following table.
     {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
     \medskip
     \end{minipage}
-    & {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
+    &
+    {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
       \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue_key }}{{ "}" }}{{ "{" }}{{ issue_key }}{{ "}" }}
+    {% endfor %}
+    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['script_results'] %}
+      {% if script_result['result_issues'] %}
+        {% for issue in script_result['result_issues'] %}
+          \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}
+        {% endfor %}
+      {% endif %}
     {% endfor %}
     \\\hline
   {% endfor %}
@@ -269,7 +277,7 @@ test case in Jira.
     \begin{longtable}{p{1cm}p{2cm}p{13cm}}
     \hline
     {Step} & \multicolumn{2}{c}{Description, Results and Status}\\ \hline
-    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['script_results'] %}
+    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['sorted'] %}
       {{ loop.index }} & Description &
 
       \begin{minipage}[t]{13cm}{\footnotesize

--- a/docsteady/templates/se-tpr.latex.jinja2
+++ b/docsteady/templates/se-tpr.latex.jinja2
@@ -25,9 +25,9 @@
 
 \setDocCompact{true}
 
-\title[\milestoneId{}~Test Report]{\milestoneId{} (\milestoneName{})~Test Plan and Report}
+\title{ {{ testplan.milestone_id }} {{ testplan.milestone_name }} Test Plan and Report}
 \setDocRef{\lsstDocType-\lsstDocNum}
-\setDocDate{\vcsdate}
+\date{\vcsdate}
 \setDocUpstreamLocation{\url{https://github.com/lsst/lsst-texmf/examples}}
 \author{ {{ testplan['owner'] }} }
 
@@ -35,7 +35,8 @@
 
 
 \setDocAbstract{
-This is the test plan and report for \milestoneId{} (\milestoneName{}), an LSST milestone pertaining to the System Engineering Subsystem.
+This is the test plan and report for {{ testplan.milestone_id }} ({{ testplan.milestone_name }}),
+an LSST milestone pertaining to the System Engineering Subsystem.
 }
 
 
@@ -81,12 +82,12 @@ Section \ref{sect:personnel} describes the necessary roles and lists the individ
 Section \ref{sect:overview} provides a summary of the test results, including an overview in Table \ref{table:summary}, an overall assessment statement and suggestions for possible improvements.
 Section \ref{sect:detailedtestresults} provides detailed results for each step in each test case.
 
-The current status of test plan {{ testplan['key'] }} in Jira is {{ testplan['status'] }}.
+The current status of test plan {{ testplan['key'] }} in Jira is \textbf{ {{ testplan['status'] }} }.
 
 \subsection{References}
 \label{sect:references}
 \renewcommand{\refname}{}
-\bibliography{lsst,refs,books,refs_ads}
+\bibliography{lsst,refs,books,refs_ads,local}
 \section{Test Configuration}
 \label{sect:configuration}
 
@@ -119,31 +120,39 @@ The current status of test plan {{ testplan['key'] }} in Jira is {{ testplan['st
   {{ testplan.pmcs_activity }}
 {% endif %}
 
+\newpage
 \section{Personnel}
 \label{sect:personnel}
 
-The following personnel are involved in this test activity:
+The personnel involved in the test campaign is shown in the following table.
 
-\begin{itemize}
-\item Test Plan ({{ testplan.key }}) owner: {{ testplan.owner }}
-\item Test Cycles:
-\begin{itemize}
+\begin{longtable}{p{3cm}p{3cm}p{3cm}p{6cm}}
+\hline
+\multicolumn{2}{r}{Test Plan ({{ testplan.key }}) owner:} &
+\multicolumn{2}{l}{\textbf{ {{ testplan.owner }} } }\\\hline
 {% for cycle in testcycles %}
-  \item {{ cycle.key }} owner: 
+\multicolumn{2}{r}{ {{ cycle.key }} owner:} &
+\multicolumn{2}{l}{\textbf{
   {% if cycle.owner %}
     {{ cycle.owner }}
   {% else %}
     Undefined
   {% endif %}
-  \begin{itemize}
+}
+} \\\hline
+\textbf{Test Case} & \textbf{Assigned to} & \textbf{Executed by} & \textbf{Additional Test Personnel} \\ \hline
   {% for test_item in cycle.test_items %}
-    \item Test case {{ test_item.test_case_key }} tester: {{ test_item.user }}
+\href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item.test_case_key }}{{ '}' }}{{ '{' }}{{ test_item.test_case_key }}{{ '}' }}
+& {\small {{ test_item.assignee }} } & {\small {{ test_item.user }} } &
+\begin{minipage}[]{6cm}
+\smallskip
+{\small {{ testcases_map[test_item.test_case_key].test_personnel }} }
+\medskip
+\end{minipage}
+\\ \hline
   {% endfor %}
-  \end{itemize}
 {% endfor %}
-\end{itemize}
-\item Additional Test Personnel involved: None
-\end{itemize}
+\end{longtable}
 
 \newpage
 
@@ -153,16 +162,24 @@ The following personnel are involved in this test activity:
 \subsection{Summary}
 \label{sect:summarytable}
 
-\begin{longtable} {p{0.12\textwidth}p{0.2\textwidth}p{0.56\textwidth}p{0.12\textwidth}}
+\begin{longtable}{p{0.12\textwidth}p{0.2\textwidth}p{0.56\textwidth}p{0.12\textwidth}}
 \toprule
 {% for cycle in testcycles %}
+
   \multicolumn{3}{c}{ Test Cycle {\bf {{ cycle.key }}: {{ cycle.name }} }} \\\hline
+
   {\bf \footnotesize test case} & {\bf \footnotesize status} & {\bf \footnotesize comment} & {\bf \footnotesize issues} \\\toprule
-  {% for test_result in testresults_map[cycle.key] %}
-    \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_result['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_result['test_case_key'] }}{{ '}' }} 
-    & {{ test_result['status'] }} & {{ test_result['comment'] }} &
-    {% for issue in test_result['result_issue_keys'] %}
-      \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue }}{{ "}" }}{{ "{" }}{{ issue }}{{ "}" }}
+
+  {% for test_item in testcycles_map[cycle.key].test_items %}
+    \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_item['test_case_key'] }}{{ '}' }}
+    & {{ test_item['status'] }} &
+    \begin{minipage}[]{0.56\textwidth}
+    \smallskip
+    {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
+    \medskip
+    \end{minipage}
+    & {% for issue_key in testresults_map[cycle.key][ test_item['test_case_key'] ]['result_issue_keys'] %}
+      \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue_key }}{{ "}" }}{{ "{" }}{{ issue_key }}{{ "}" }}
     {% endfor %}
     \\\hline
   {% endfor %}
@@ -221,31 +238,30 @@ Open test cycle {\it \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testrun/
 
   \subsubsection{Test Cases in {{ cycle.key }} Test Cycle}
 
-  {% for test_result in testresults_map[cycle.key] %}
+  {% for test_item in testcycles_map[cycle.key].test_items %}
 
-    \paragraph{Test Case {{ test_result['test_case_key'] }} }\mbox{}\\
+    \paragraph{Test Case {{ test_item['test_case_key'] }} - {{ testcases_map[ test_item['test_case_key'] ]['name'] }} }\mbox{}\\
 
-Open  \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_result['test_case_key'] }}}{\textit{ {{ test_result['test_case_key'] }} } }
+Open  \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}}{\textit{ {{ test_item['test_case_key'] }} } }
 test case in Jira.
 
-    {{  testcases_map[test_result['test_case_key']]['objective'] }}
+    {{  testcases_map[ test_item['test_case_key'] ]['objective'] }}
 
-    {\bf Preconditions}:\\
-    {{ testcases_map[test_result['test_case_key']]['precondition'] }}
+    \textbf{ Preconditions}:\\
+    {{ testcases_map[ test_item['test_case_key'] ]['precondition'] }}
 
-    Execution status: {\bf {{  test_result['status'] }} }
+    Execution status: {\bf {{  test_item['status'] }} }
 
-    Final comment:\\{{ test_result['comment'] }}
+    Final comment:\\{{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
 
-    {% if test_result['issues'] %}
-      Issues found during the execution of {{ test_result['test_case_key'] }} test case:
+    {% if testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
+      Issues found during the execution of {{ test_item['test_case_key'] }} test case:
 
       \begin{itemize}
-      {% for issue in test_result['issues'] %}
+      {% for issue in testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
         \item {{ issue['id'] }}: {{ issue['summary'] }}
       {% endfor %}
       \end{itemize}
-
     {% endif %}
 
     Detailed step results:
@@ -253,7 +269,7 @@ test case in Jira.
     \begin{longtable}{p{1cm}p{2cm}p{13cm}}
     \hline
     {Step} & \multicolumn{2}{c}{Description, Results and Status}\\ \hline
-    {% for script_result in test_result['script_results'] %}
+    {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['script_results'] %}
       {{ loop.index }} & Description &
 
       \begin{minipage}[t]{13cm}{\footnotesize
@@ -262,7 +278,26 @@ test case in Jira.
       } \end{minipage} \\
       \\ \cdashline{2-3}
 
-      & Expected Result & 
+      {% if 'example_code' in script_result.custom_field_values %}
+      & Example Code &
+
+      \begin{minipage}[t]{13cm}{\footnotesize
+      {{ script_result.custom_field_values.example_code }}
+      \vspace{\dp0}
+      } \end{minipage} \\
+      \\ \cdashline{2-3}
+      {% endif %}
+
+      {% if script_result['testdata'] %}
+        & Test Data        &
+        \begin{minipage}[t]{13cm}{\smallskip \footnotesize
+        {{ script_result['testdata'] }}
+        \medskip
+        } \end{minipage} \\
+        \\ \cdashline{2-3}
+      {% endif %}
+
+      & Expected Result &
 
       \begin{minipage}[t]{13cm}{\footnotesize
       {{ script_result['expected_result'] }}

--- a/docsteady/templates/se-tpr.latex.jinja2
+++ b/docsteady/templates/se-tpr.latex.jinja2
@@ -17,6 +17,8 @@
 \providecommand{\tightlist}{
   \setlength{\itemsep}{0pt}\setlength{\parskip}{0pt}}
 
+\setcounter{tocdepth}{4}
+
 \begin{document}
 
 \def\milestoneName{{ '{' }}{{ testplan.milestone_name }}{{ '}' }}
@@ -156,24 +158,25 @@ The personnel involved in the test campaign is shown in the following table.
 
 \newpage
 
-\section{Overview of the Test Results}
+\section{Test Campaign Overview}
 \label{sect:overview}
 
 \subsection{Summary}
 \label{sect:summarytable}
 
-\begin{longtable}{p{0.12\textwidth}p{0.2\textwidth}p{0.56\textwidth}p{0.12\textwidth}}
+\begin{longtable}{p{2cm}p{2.5cm}p{9cm}p{2.5cm}}
 \toprule
+\multicolumn{3}{l}{ Test Plan {\bf {{ testplan['key'] }}: {{ testplan['name'] }} }} & {{ testplan['status'] }} \\\hline
 {% for cycle in testcycles %}
 
-  \multicolumn{3}{c}{ Test Cycle {\bf {{ cycle.key }}: {{ cycle.name }} }} \\\hline
+  \multicolumn{3}{l}{ Test Cycle {\bf {{ cycle.key }}: {{ cycle.name }} }} & {{ cycle.status }} \\\hline
 
   {\bf \footnotesize test case} & {\bf \footnotesize status} & {\bf \footnotesize comment} & {\bf \footnotesize issues} \\\toprule
 
   {% for test_item in testcycles_map[cycle.key].test_items %}
     \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}{{ '}' }}{{ '{' }}{{ test_item['test_case_key'] }}{{ '}' }}
     & {{ test_item['status'] }} &
-    \begin{minipage}[]{0.56\textwidth}
+    \begin{minipage}[]{9cm}
     \smallskip
     {{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
     \medskip
@@ -192,7 +195,6 @@ The personnel involved in the test campaign is shown in the following table.
     \\\hline
   {% endfor %}
 {% endfor %}
-
 \caption{Test Results Summary}
 \label{table:summary}
 \end{longtable}
@@ -220,121 +222,116 @@ Not yet available.
 \label{sect:detailedtestresults}
 
 {% for cycle in testcycles %}
-
-  \subsection{Test Cycle {{ cycle.key }} }
+\subsection{Test Cycle {{ cycle.key }} }
 
 Open test cycle {\it \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testrun/{{ cycle.key }}}{{ '{' }}{{ cycle.name }}{{ '}' }}} in Jira.
 
-  {{ cycle.name }}\\
-  Status: {{cycle.status }}
+{{ cycle.name }}\\
+Status: {{ cycle.status }}
 
-  {{ cycle.description }}
+{{ cycle.description }}
 
-  \subsubsection{Software Version/Baseline}
+\subsubsection{Software Version/Baseline}
   {% if cycle.software_version %}
-    {{cycle.software_version}}
+{{cycle.software_version}}
   {% else %}
-    Not provided.
+Not provided.
   {% endif %}
 
-  \subsubsection{Configuration}
+\subsubsection{Configuration}
   {% if cycle.configuration %}
-    {{ cycle.configuration }}
+{{ cycle.configuration }}
   {% else %}
-    Not provided.
+Not provided.
   {% endif %}
 
-  \subsubsection{Test Cases in {{ cycle.key }} Test Cycle}
+\subsubsection{Test Cases in {{ cycle.key }} Test Cycle}
 
   {% for test_item in testcycles_map[cycle.key].test_items %}
-
-    \paragraph{Test Case {{ test_item['test_case_key'] }} - {{ testcases_map[ test_item['test_case_key'] ]['name'] }} }\mbox{}\\
+\paragraph{Test Case {{ test_item['test_case_key'] }} - {{ testcases_map[ test_item['test_case_key'] ]['name'] }} }\mbox{}\\
 
 Open  \href{https://jira.lsstcorp.org/secure/Tests.jspa#/testCase/{{ test_item['test_case_key'] }}}{\textit{ {{ test_item['test_case_key'] }} } }
 test case in Jira.
 
-    {{  testcases_map[ test_item['test_case_key'] ]['objective'] }}
+{{  testcases_map[ test_item['test_case_key'] ]['objective'] }}
 
-    \textbf{ Preconditions}:\\
-    {{ testcases_map[ test_item['test_case_key'] ]['precondition'] }}
+\textbf{ Preconditions}:\\
+{{ testcases_map[ test_item['test_case_key'] ]['precondition'] }}
 
-    Execution status: {\bf {{  test_item['status'] }} }
+Execution status: {\bf {{  test_item['status'] }} }
 
-    Final comment:\\{{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
+Final comment:\\{{ testresults_map[cycle.key][ test_item['test_case_key'] ]['comment'] }}
 
     {% if testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
-      Issues found during the execution of {{ test_item['test_case_key'] }} test case:
+Issues found during the execution of {{ test_item['test_case_key'] }} test case:
 
-      \begin{itemize}
+\begin{itemize}
       {% for issue in testresults_map[cycle.key][ test_item['test_case_key'] ]['issues'] %}
-        \item {{ issue['id'] }}: {{ issue['summary'] }}
+\item \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
       {% endfor %}
-      \end{itemize}
+\end{itemize}
     {% endif %}
 
-    Detailed step results:
+Detailed steps results:
 
-    \begin{longtable}{p{1cm}p{2cm}p{13cm}}
-    \hline
-    {Step} & \multicolumn{2}{c}{Description, Results and Status}\\ \hline
+\begin{longtable}{p{1cm}p{15cm}}
+\hline
+{Step} & Step Details\\ \hline
     {% for script_result in testresults_map[cycle.key][ test_item['test_case_key'] ]['sorted'] %}
-      {{ loop.index }} & Description &
-
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result['description'] }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
+{{ loop.index }} & Description \\
+ & \begin{minipage}[t]{15cm}
+{\footnotesize
+\smallskip
+{{ script_result['description'] }}
+\medskip }
+\end{minipage}
+\\ \cdashline{2-2}
 
       {% if 'example_code' in script_result.custom_field_values %}
-      & Example Code &
-
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result.custom_field_values.example_code }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
+ & Example Code \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result.custom_field_values.example_code }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
       {% endif %}
-
       {% if script_result['testdata'] %}
-        & Test Data        &
-        \begin{minipage}[t]{13cm}{\smallskip \footnotesize
-        {{ script_result['testdata'] }}
-        \medskip
-        } \end{minipage} \\
-        \\ \cdashline{2-3}
+ & Test Data \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result['testdata'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
       {% endif %}
 
-      & Expected Result &
+ & Expected Result \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result['expected_result'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
 
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result['expected_result'] }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
-
-      & \begin{minipage}[t]{2cm}{Actual\\ Result}\end{minipage}   & 
-      \begin{minipage}[t]{13cm}{\footnotesize
-      {{ script_result['comment'] }}
-      \vspace{\dp0}
-      } \end{minipage} \\
-      \\ \cdashline{2-3}
+ & Actual Result \\
+ & \begin{minipage}[t]{15cm}{\footnotesize
+\smallskip
+{{ script_result['comment'] }}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
 
       {% if script_result['result_issues'] %}
-        & Issues        &
-        \begin{minipage}[t]{13cm}{\footnotesize
+ & Issues found executing this step:  \\
+ & \begin{minipage}[t]{13cm}{\footnotesize
+\smallskip
         {% for issue in script_result['result_issues'] %}
-          \href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
+\href{{ "{" }}https://jira.lsstcorp.org/browse/{{ issue['key'] }}{{ "}" }}{{ "{" }}{{ issue['key'] }}{{ "}" }}~~{{ issue['summary'] }}
         {% endfor %}
-        \vspace{\dp0}
-        } \end{minipage} \\
-        \\ \cdashline{2-3}
+\medskip }
+\end{minipage} \\ \cdashline{2-2}
       {% endif %}
-
-      & Status          & {{ script_result['status'] }} \\ \hline
+ & Status: \textbf{ {{ script_result['status'] }} } \\ \hline
 
     {% endfor %}
-    \end{longtable}
+\end{longtable}
 
   {% endfor %}
 {% endfor %}

--- a/docsteady/tplan.py
+++ b/docsteady/tplan.py
@@ -131,10 +131,12 @@ def build_tpr_model(tplan_id):
 
     for cycle_key in testplan['cycles']:
         resp = requests.get(Config.TESTCYCLE_URL.format(testrun=cycle_key), auth=Config.AUTH)
+        print("  >  ", Config.TESTCYCLE_URL.format(testrun=cycle_key))
         test_cycle, error = TestCycle().load(resp.json())
         test_cycles_map[cycle_key] = test_cycle
 
         resp = requests.get(Config.TESTRESULTS_URL.format(testrun=cycle_key), auth=Config.AUTH)
+        print("  >>  ", Config.TESTRESULTS_URL.format(testrun=cycle_key))
         resp.raise_for_status()
         testresults, errors = TestResult().load(resp.json(), many=True)
         test_results_map[cycle_key] = {}
@@ -146,6 +148,7 @@ def build_tpr_model(tplan_id):
             if test_item['test_case_key'] not in test_cases_map.keys():
                 resp = requests.get(Config.TESTCASE_URL.format(testcase=test_item['test_case_key']),
                                     auth=Config.AUTH)
+                print("  >>>  ", Config.TESTCASE_URL.format(testcase=test_item['test_case_key']))
                 testcase, errors = TestCase().load(resp.json())
                 test_cases_map[test_item['test_case_key']] = testcase
 

--- a/docsteady/tplan.py
+++ b/docsteady/tplan.py
@@ -25,7 +25,7 @@ import requests
 from marshmallow import Schema, fields, pre_load
 
 from docsteady.cycle import TestCycle, TestResult
-from docsteady.spec import Issue, TestCase
+from docsteady.spec import TestCase
 from docsteady.utils import owner_for_id, as_arrow, HtmlPandocField, SubsectionableHtmlPandocField
 from .config import Config
 

--- a/docsteady/tplan.py
+++ b/docsteady/tplan.py
@@ -131,16 +131,15 @@ def build_tpr_model(tplan_id):
 
     for cycle_key in testplan['cycles']:
         resp = requests.get(Config.TESTCYCLE_URL.format(testrun=cycle_key), auth=Config.AUTH)
-        print("  >  ", Config.TESTCYCLE_URL.format(testrun=cycle_key))
         test_cycle, error = TestCycle().load(resp.json())
         test_cycles_map[cycle_key] = test_cycle
 
         resp = requests.get(Config.TESTRESULTS_URL.format(testrun=cycle_key), auth=Config.AUTH)
-        print("  >>  ", Config.TESTRESULTS_URL.format(testrun=cycle_key))
         resp.raise_for_status()
         testresults, errors = TestResult().load(resp.json(), many=True)
         test_results_map[cycle_key] = {}
         for result in testresults:
+            result['sorted'] = sorted(result['script_results'], key=lambda step: step["index"])
             test_results_map[cycle_key][result['test_case_key']] = result
 
         # Get all the test cases from the test items
@@ -148,7 +147,6 @@ def build_tpr_model(tplan_id):
             if test_item['test_case_key'] not in test_cases_map.keys():
                 resp = requests.get(Config.TESTCASE_URL.format(testcase=test_item['test_case_key']),
                                     auth=Config.AUTH)
-                print("  >>>  ", Config.TESTCASE_URL.format(testcase=test_item['test_case_key']))
                 testcase, errors = TestCase().load(resp.json())
                 test_cases_map[test_item['test_case_key']] = testcase
 

--- a/docsteady/tplan.py
+++ b/docsteady/tplan.py
@@ -140,6 +140,7 @@ def build_tpr_model(tplan_id):
         test_results_map[cycle_key] = {}
         for result in testresults:
             result['sorted'] = sorted(result['script_results'], key=lambda step: step["index"])
+            # result['sorted'] = result['script_results']
             test_results_map[cycle_key][result['test_case_key']] = result
 
         # Get all the test cases from the test items

--- a/docsteady/utils.py
+++ b/docsteady/utils.py
@@ -145,6 +145,9 @@ def download_and_rewrite_images(value):
     soup = BeautifulSoup(value.encode("utf-8"), "html.parser", from_encoding="utf-8")
     rest_location = urljoin(Config.JIRA_INSTANCE, "rest")
     for img in soup.find_all("img"):
+        # print(img)
+        img_style = urljoin(rest_location, img["style"])
+        img_width = re.sub('[^0-9]','', img_style)
         img_url = urljoin(rest_location, img["src"])
         url_path = urlparse(img_url).path[1:]
         img_name = os.path.basename(url_path)
@@ -169,14 +172,14 @@ def download_and_rewrite_images(value):
                 fs_path = f"{fs_path}.{extension}"
                 with open(fs_path, "w+b") as img_f:
                     img_f.write(resp.content)
-        im = Image.open(fs_path)
-        width, height = im.size
-        if width > Config.MAX_IMG_PIXELS:
-            print(f"[WARNING] Image {fs_path} width greater than {Config.MAX_IMG_PIXELS} pixels.")
-            img["width"] = f"{Config.MAX_IMG_PIXELS}px"
         if img.previous_element.name != "br":
             img.insert_before(soup.new_tag("br"))
         img["style"] = ""
+        # fixing the aspect ratio of th images is working only with pandic 1.19.1
+        #
+        img["width"] = f"{img_width}px"
+        img["display"] = "block"
+        img["height"] = "auto"
         img["src"] = fs_path
     return str(soup)
 

--- a/docsteady/utils.py
+++ b/docsteady/utils.py
@@ -145,9 +145,7 @@ def download_and_rewrite_images(value):
     soup = BeautifulSoup(value.encode("utf-8"), "html.parser", from_encoding="utf-8")
     rest_location = urljoin(Config.JIRA_INSTANCE, "rest")
     for img in soup.find_all("img"):
-        # print(img)
-        img_style = urljoin(rest_location, img["style"])
-        img_width = re.sub('[^0-9]','', img_style)
+        img_width = re.sub('[^0-9]', '', img["style"])
         img_url = urljoin(rest_location, img["src"])
         url_path = urlparse(img_url).path[1:]
         img_name = os.path.basename(url_path)


### PR DESCRIPTION
A large number of fixes have been made on the test plan and report generation:
- DM-22425: added traceability to verification elements in the appendix, option using extra input parameter (--trace)
- DM-22429: reshaped section3 (Personel) into a table
- DM-22429: added minipage to avoid formatting problems in the summary table
- improved the management of images: now they are scaled following the width defined in Jira/ATM UI
- generally improved the detailed test step result, in order to have more space for narrative
- added TPR template for SE
- fixed the order of the steps, since rest API return them unordered when test cases are still to be executed.
- increased to 4 the TOC depth
