### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ following commands are available:
 * `generate-vcd`: to generate the Verification Control Documents
 * `baseline-ve`: to generate Verification Elements baseline documents.
 
-See [The docs](docsteady.lsst.io).
+See [the docsteady documentation](https://docsteady.lsst.io/).
 
 
 # Developers


### PR DESCRIPTION
The documentation link in the README was rendering incorrectly.